### PR TITLE
Make domain_name optional + BaseKit login fixes

### DIFF
--- a/src/Data/AccountIdentifier.php
+++ b/src/Data/AccountIdentifier.php
@@ -9,7 +9,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
 
 /**
  * @property-read string|integer $account_reference
- * @property-read string $domain_name
+ * @property-read string|null $domain_name
  */
 class AccountIdentifier extends DataSet
 {
@@ -17,7 +17,7 @@ class AccountIdentifier extends DataSet
     {
         return new Rules([
             'account_reference' => ['required'],
-            'domain_name' => ['required', 'domain_name'],
+            'domain_name' => ['nullable', 'domain_name'],
         ]);
     }
 }

--- a/src/Data/AccountInfo.php
+++ b/src/Data/AccountInfo.php
@@ -9,7 +9,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
 
 /**
  * @property-read string|integer $account_reference
- * @property-read string $domain_name
+ * @property-read string|null $domain_name
  * @property-read string|integer $package_reference
  * @property-read bool $suspended
  * @property-read integer|null $site_count
@@ -21,7 +21,7 @@ class AccountInfo extends ResultData
     {
         return new Rules([
             'account_reference' => ['required'],
-            'domain_name' => ['required', 'domain_name'],
+            'domain_name' => ['nullable', 'domain_name'],
             'package_reference' => ['required'],
             'suspended' => ['nullable', 'bool'],
             'site_count' => ['nullable', 'integer'],

--- a/src/Data/ChangePackageParams.php
+++ b/src/Data/ChangePackageParams.php
@@ -9,7 +9,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
 
 /**
  * @property-read string|integer $account_reference
- * @property-read string $domain_name
+ * @property-read string|null $domain_name
  * @property-read string|integer $package_reference
  * @property-read integer $billing_cycle_months
  */
@@ -19,7 +19,7 @@ class ChangePackageParams extends DataSet
     {
         return new Rules([
             'account_reference' => ['required'],
-            'domain_name' => ['required', 'domain_name'],
+            'domain_name' => ['nullable', 'domain_name'],
             'package_reference' => ['required'],
             'billing_cycle_months' => ['required', 'integer'],
         ]);

--- a/src/Data/CreateParams.php
+++ b/src/Data/CreateParams.php
@@ -11,7 +11,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
  * @property-read string|integer $customer_id
  * @property-read string $customer_name
  * @property-read string $customer_email
- * @property-read string $domain_name
+ * @property-read string|null $domain_name
  * @property-read string|integer $package_reference
  * @property-read integer $billing_cycle_months
  * @property-read string|null $password
@@ -25,7 +25,7 @@ class CreateParams extends DataSet
             'customer_id' => ['required'],
             'customer_name' => ['required', 'string'],
             'customer_email' => ['required', 'email'],
-            'domain_name' => ['required', 'domain-name'],
+            'domain_name' => ['nullable', 'domain-name'],
             'package_reference' => ['required'],
             'billing_cycle_months' => ['required', 'integer'],
             'password' => ['nullable', 'string'],

--- a/src/Data/UnSuspendParams.php
+++ b/src/Data/UnSuspendParams.php
@@ -9,7 +9,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
 
 /**
  * @property-read string|integer $account_reference
- * @property-read string $domain_name
+ * @property-read string|null $domain_name
  * @property-read string|integer $package_reference
  * @property-read integer $billing_cycle_months
  */
@@ -19,7 +19,7 @@ class UnSuspendParams extends DataSet
     {
         return new Rules([
             'account_reference' => ['required'],
-            'domain_name' => ['required', 'domain_name'],
+            'domain_name' => ['nullable', 'domain_name'],
             'package_reference' => ['required'],
             'billing_cycle_months' => ['required', 'integer'],
         ]);

--- a/src/Providers/BaseKit/Data/Configuration.php
+++ b/src/Providers/BaseKit/Data/Configuration.php
@@ -13,6 +13,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
  * @property-read string $password
  * @property-read string $brand_ref
  * @property-read string $suspension_package_ref
+ * @property-read string|null $auto_login_redirect_url
  */
 class Configuration extends DataSet
 {
@@ -24,6 +25,7 @@ class Configuration extends DataSet
             'password' => ['required', 'string'],
             'brand_ref' => ['required', 'numeric'],
             'suspension_package_ref' => ['required', 'numeric'],
+            'auto_login_redirect_url' => ['nullable', 'url'],
         ]);
     }
 }

--- a/src/Providers/BaseKit/Data/Configuration.php
+++ b/src/Providers/BaseKit/Data/Configuration.php
@@ -14,6 +14,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
  * @property-read string $brand_ref
  * @property-read string $suspension_package_ref
  * @property-read string|null $auto_login_redirect_url
+ * @property-read bool $debug_mode
  */
 class Configuration extends DataSet
 {
@@ -26,6 +27,7 @@ class Configuration extends DataSet
             'brand_ref' => ['required', 'numeric'],
             'suspension_package_ref' => ['required', 'numeric'],
             'auto_login_redirect_url' => ['nullable', 'url'],
+            'debug_mode' => ['boolean'],
         ]);
     }
 }

--- a/src/Providers/BaseKit/Provider.php
+++ b/src/Providers/BaseKit/Provider.php
@@ -417,6 +417,8 @@ class Provider extends Category implements ProviderInterface, LogsDebugData
                 'Accept' => 'application/json',
                 'User-Agent' => 'upmind/provision-provider-website-builders v1.0'
             ],
+            RequestOptions::TIMEOUT => 10, // seconds
+            RequestOptions::CONNECT_TIMEOUT => 5, // seconds
             'handler' => $this->getGuzzleHandlerStack(boolval($this->configuration->debug_mode))
         ]);
     }

--- a/src/Providers/BaseKit/Provider.php
+++ b/src/Providers/BaseKit/Provider.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\ResponseInterface;
 use stdClass;
 use Throwable;
 use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionBase\Provider\Contract\LogsDebugData;
 use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
 use Upmind\ProvisionBase\Provider\DataSet\ResultData;
@@ -26,7 +27,7 @@ use Upmind\ProvisionProviders\WebsiteBuilders\Data\UnSuspendParams;
 use Upmind\ProvisionProviders\WebsiteBuilders\Providers\BaseKit\Data\Configuration;
 use Upmind\ProvisionProviders\WebsiteBuilders\Utils\Helpers;
 
-class Provider extends Category implements ProviderInterface
+class Provider extends Category implements ProviderInterface, LogsDebugData
 {
     /**
      * @var Configuration
@@ -416,6 +417,7 @@ class Provider extends Category implements ProviderInterface
                 'Accept' => 'application/json',
                 'User-Agent' => 'upmind/provision-provider-website-builders v1.0'
             ],
+            'handler' => $this->getGuzzleHandlerStack(boolval($this->configuration->debug_mode))
         ]);
     }
 }

--- a/src/Providers/BaseKit/Provider.php
+++ b/src/Providers/BaseKit/Provider.php
@@ -275,14 +275,10 @@ class Provider extends Category implements ProviderInterface
         ]);
         $data = $this->getResponseData($response);
 
-        if (!empty($data->flowUrl)) {
-            return $data->flowUrl;
-        }
+        $r = $this->configuration->auto_login_redirect_url;
 
-        $hash = $data->hash;
-
-        return Str::replaceFirst('rest', 'flow', $this->configuration->api_url)
-            . '/login?' . http_build_query(compact('hash'));
+        $join = Str::contains($data->flowUrl, '?') ? '&' : '?';
+        return $data->flowUrl . $join . http_build_query(compact('r'));
     }
 
     /**

--- a/src/Providers/BaseKit/Provider.php
+++ b/src/Providers/BaseKit/Provider.php
@@ -149,9 +149,9 @@ class Provider extends Category implements ProviderInterface
 
     /**
      * @param int $userReference
-     * @param string $domainName
+     * @param string|null $domainName
      */
-    public function getAccountInfo($userReference, string $domainName): AccountInfo
+    public function getAccountInfo($userReference, ?string $domainName = null): AccountInfo
     {
         $userData = $this->getUserData($userReference);
         $packageRef = $userData->subscriptionPackageRef;
@@ -159,6 +159,10 @@ class Provider extends Category implements ProviderInterface
 
         $sitesData = $this->getUserSitesData($userReference);
         $numSites = count($sitesData);
+
+        if (is_null($domainName)) {
+            $domainName = $sitesData[0]->primaryDomain->domainName ?? null;
+        }
 
         return AccountInfo::create([
             'account_reference' => $userReference,
@@ -260,9 +264,9 @@ class Provider extends Category implements ProviderInterface
 
     /**
      * @param int $userReference
-     * @param string $domainName
+     * @param string|null $domainName
      */
-    public function getLoginUrl($userReference, string $domainName): string
+    public function getLoginUrl($userReference, ?string $domainName = null): string
     {
         $response = $this->client()->post(sprintf('/users/%s/auto-login', $userReference), [
             RequestOptions::JSON => [
@@ -283,14 +287,14 @@ class Provider extends Category implements ProviderInterface
 
     /**
      * @param int $userReference
-     * @param string $domainName
+     * @param string|null $domainName
      */
-    public function getDomainSiteReference($userReference, string $domainName): int
+    public function getDomainSiteReference($userReference, ?string $domainName = null): int
     {
         $sitesData = $this->getUserSitesData($userReference);
 
         foreach ($sitesData as $site) {
-            if (strcasecmp($domainName, $site->primaryDomain->domainName) === 0) {
+            if ($domainName && strcasecmp($domainName, $site->primaryDomain->domainName) === 0) {
                 return $site->ref;
             }
         }


### PR DESCRIPTION
- Make `domain_name` an optional parameter and return data property
- Implement a configurable redirect url for BaseKit `login()`
- Add configurable debug logging for BaseKit API requests + responses