### PR TITLE
Duda template handling for Create site & Login to site functions

### DIFF
--- a/src/Providers/Duda/Helper/DudaApi.php
+++ b/src/Providers/Duda/Helper/DudaApi.php
@@ -94,6 +94,8 @@ class DudaApi
     /**
      * Get template data by the given template name or ID.
      *
+     * @throws GuzzleException
+     *
      * @link https://developer.duda.co/reference/templates-list-templates
      */
     public function getTemplate(string $template): array
@@ -126,7 +128,7 @@ class DudaApi
         $plan = $this->makeRequest("sites/multiscreen/$siteId/plan");
         $permissions = $this->makeRequest("accounts/{$accountName}/sites/{$siteId}/permissions");
 
-        $isPublished = $site['publish_status'] == 'PUBLISHED';
+        $isPublished = $site['publish_status'] === 'PUBLISHED';
 
         return [
             'site_builder_user_id' => $account['account_name'],
@@ -282,21 +284,19 @@ class DudaApi
         ?int $templateId
     ): string {
         $body = [
-            'template_id' => 0,
+            'template_id' => $templateId,
             'lang' => $this->getSupportedLanguage($lang),
             'site_data' => [
                 'site_domain' => $domain
             ],
         ];
 
+        if ($templateId === null) {
+            unset($body['template_id']);
+        }
+
         $site = $this->makeRequest("sites/multiscreen/create", null, $body, 'POST');
         $siteId = $site['site_name'];
-
-        if ($templateId) {
-            $this->makeRequest('sites/multiscreen/switchTemplate/' . $siteId, null, [
-                'template_id' => $templateId,
-            ], 'POST');
-        }
 
         $this->setSitePermissions($siteId, $accountName, $permissions);
 

--- a/src/Providers/Duda/Provider.php
+++ b/src/Providers/Duda/Provider.php
@@ -6,7 +6,6 @@ namespace Upmind\ProvisionProviders\WebsiteBuilders\Providers\Duda;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Str;
 use Throwable;
@@ -89,7 +88,7 @@ class Provider extends Category implements ProviderInterface
             );
 
             return $this->getAccountInfo($account['account_name'], $siteId, 'Website created');
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->handleException($e, $params);
         }
     }


### PR DESCRIPTION
- Creating a website should use the provided template ID and remove if not set, instead of switching template. Duda has replaced classic edit with AI editor on the creation flow and this was blocking the flow
- Login to a website should always go to `EDITOR` if a site is created but is still unpublished. This scenario might happen if a user wants to do some extra changes before publishing. A created site but not published will return `-1` to the template ID of the site info